### PR TITLE
Ensure Lv2_Coron handles only Coronagraphic exposures and Lv2_Image creates rate-based results

### DIFF
--- a/jwst/associations/lib/dms_base.py
+++ b/jwst/associations/lib/dms_base.py
@@ -833,7 +833,13 @@ class Constraint_TSO(Constraint):
 
 class Constraint_Coron(Constraint):
     """Match on Coronagraphic Observations"""
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, association=None, **kwargs):
+
+        if association is None:
+            sources = lambda item: True
+        else:
+            sources = association.is_item_coron
+
         super(Constraint_Coron, self).__init__(
             [
                 DMSAttrConstraint(
@@ -843,6 +849,10 @@ class Constraint_Coron(Constraint):
                 DMSAttrConstraint(
                     sources=['exp_type'],
                     value='|'.join(CORON_EXP_TYPES),
+                ),
+                SimpleConstraint(
+                    value=True,
+                    sources=sources
                 ),
             ],
         )

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -131,6 +131,16 @@ class Asn_Lv2Image(
         # Now check and continue initialization.
         super(Asn_Lv2Image, self).__init__(*args, **kwargs)
 
+    def is_item_coron(self, item):
+        """Override to ignore coronographic designation
+
+        Coronagraphic data is to be processed both as coronagraphic
+        (by default), but also as just plain imaging. Coronagraphic
+        data is processed using the Ans_Lv2Coron rul. This rule
+        will handle the creation of the image version.
+        """
+        return False
+
 
 @RegistryMarker.rule
 class Asn_Lv2ImageNonScience(

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -77,11 +77,7 @@ class Asn_Lv2Coron(
         self.constraints = Constraint([
             Constraint_Base(),
             Constraint_Mode(),
-            Constraint_Coron(),
-            Constraint(
-                [Constraint_TSO()],
-                reduce=Constraint.notany
-            ),
+            Constraint_Coron(association=self),
             Constraint(
                 [
                     Constraint_Background(),


### PR DESCRIPTION
Two issues found:

1. Lv2_Image was producing associations, but still had the `rateints` as inputs. Fix is to ensure that all coronographic data is not handled as coronographic for Lv2_Image
2. Lv2_Coron was producing associations for all detectors, regardless of whether the detector should be considered coronagraphic or not. The current mods do get the `rate` vs. `rateints` correct. However, the `rate` version should be handled solely by Lv2_image. Hence this modification.

Note that these issues could not be seen because the duplication check was removing most of the Lv2_Image associations. One can verify operation by commenting out rules_level2_base.py:570-572. Do not commit this change however. A non-invasive way to get the duplicates is to use the `-D` option. This will save the duplicates with a "dupxxx" prefix.

There are two issues beyond the current PR: One has to do with PSF and Lv_Image2 vs. Lv_ImageSpecial. This is related to a recent change to have PSF's background-subtracted and was masked by the duplication checking

The other is the duplication checking. Tech-debt has built up around this. It will not be much to sort out, but it needs sorting out.

Paths forward are either:

1.  Howard's PR waits and includes the two issues above
2. Howard's PR moves forward and gets merged. This would not update any truths and the regressions will either be allowed to fail or failing ones be skipped. Then the two issues above are handled by another PR.

Let's discuss offline.