### PR TITLE
Refactor association duplication checking to allow rate vs rateints

### DIFF
--- a/jwst/associations/lib/diff.py
+++ b/jwst/associations/lib/diff.py
@@ -359,17 +359,12 @@ def compare_product_membership(left, right):
 
     if len(left_unaccounted_members):
         diffs.append(UnaccountedMembersError(
-            f'Left has {len(left_unaccounted_members)}. Members are {left_unaccounted_members}'
+            f'Left has {len(left_unaccounted_members)} unaccounted members. Members are {left_unaccounted_members}'
         ))
 
     if len(members_right) != 0:
         diffs.append(UnaccountedMembersError(
-            'Right has {len_over} unaccounted for members starting with'
-            ' {right_expname}:{right_exptype}'
-            ''.format(len_over=len(members_right),
-                      right_expname=members_right[0]['expname'],
-                      right_exptype=members_right[0]['exptype']
-            )
+            f'Right has {len(members_right)} unaccounted members. Members are {members_right}'
         ))
 
     if diffs:

--- a/jwst/associations/lib/product_utils.py
+++ b/jwst/associations/lib/product_utils.py
@@ -2,6 +2,7 @@
 
 from collections import defaultdict, Counter
 import logging
+from pathlib import Path
 
 from ...lib.suffix import remove_suffix
 from .. import config
@@ -230,11 +231,11 @@ def compare_nosuffix(left, right):
         return False
 
     for left_product in left['products']:
-        left_sciences = set(remove_suffix(member['expname'])[0]
+        left_sciences = set(exposure_name(member['expname'])[0]
                          for member in left_product['members']
                          if member['exptype'] == 'science')
         for right_product in right['products']:
-            right_sciences = set(remove_suffix(member['expname'])[0]
+            right_sciences = set(exposure_name(member['expname'])[0]
                               for member in right_product['members']
                               if member['exptype'] == 'science')
             if left_sciences == right_sciences:
@@ -247,6 +248,24 @@ def compare_nosuffix(left, right):
     # Every left product has a matching right product.
     # Except for suffix, the associations are considered a match.
     return True
+
+
+def exposure_name(path):
+    """Extract the exposure name from a Stage 2 file name
+
+    Parameters
+    ----------
+    path : Path or str
+        The file name or path.
+
+    Returns
+    -------
+    exposure : str
+        The exposure name
+    """
+    path = Path(path)
+    exposure = remove_suffix(path.stem)
+    return exposure
 
 
 def prune_remove(remove_from, to_remove, known_dups):

--- a/jwst/associations/lib/product_utils.py
+++ b/jwst/associations/lib/product_utils.py
@@ -122,7 +122,9 @@ def prune_duplicate_associations(asns):
         Pruned list of associations
 
     """
-    ordered_asns = sort_by_candidate(asns)
+    known_dups, valid_asns = identify_dups(asns)
+
+    ordered_asns = sort_by_candidate(valid_asns)
     pruned = list()
     while True:
         try:
@@ -139,7 +141,7 @@ def prune_duplicate_associations(asns):
             to_prune.append(asn)
         prune_remove(ordered_asns, to_prune)
 
-    return pruned
+    return pruned + known_dups
 
 
 def prune_duplicate_products(asns):
@@ -158,7 +160,9 @@ def prune_duplicate_products(asns):
         Pruned list of associations
 
     """
-    product_names, dups = get_product_names(asns)
+    known_dups, valid_asns = identify_dups(asns)
+
+    product_names, dups = get_product_names(valid_asns)
     if not dups:
         return asns
 
@@ -193,7 +197,7 @@ def prune_duplicate_products(asns):
                 to_prune.append(asn)
 
     prune_remove(ordered_asns, to_prune)
-    return ordered_asns
+    return ordered_asns + known_dups
 
 
 def prune_remove(remove_from, to_remove):
@@ -225,3 +229,25 @@ def prune_remove(remove_from, to_remove):
             asn.asn_name = f'dup{DupCount:05d}_{asn.asn_name}'
         else:
             remove_from.remove(asn)
+
+
+def identify_dups(asns):
+    """Separate associations based on whether they have already been identified as dups
+
+    Parameters
+    ----------
+    asns: [Association[,...]]
+        Associations to prune
+
+    Returns
+    identified, valid : [Association[,...]], [Association[,...]]
+        Dup-identified and valid associations
+    """
+    identified = list()
+    valid = list()
+    for asn in asns:
+        if asn.asn_name.startswith('dup'):
+            identified.append(asn)
+        else:
+            valid.append(asn)
+    return identified, valid

--- a/jwst/associations/lib/product_utils.py
+++ b/jwst/associations/lib/product_utils.py
@@ -66,6 +66,36 @@ def get_product_names(asns):
     return set(product_names), dups
 
 
+def prune(asns):
+    """Remove duplicates and subset associations
+
+    Situations where extraneous associations can occur are:
+
+    - duplicate memberships
+    - duplicate product names
+
+    Associations with different product names but same memberships arise when
+    different levels of candidates gather the same membership, such as
+    OBSERVATION vs. GROUP. Associations of the lower level candidate are preferred.
+
+    Associations with the same product name can occur in Level 2 when both an OBSERVATION
+    candidate and a BACKGROUND candidate associations are created. The association that is
+    a superset of members is the one chosen.
+
+    Parameters
+    ----------
+    asns : [Association[,...]]
+        Associations to prune
+
+    Returns
+    -------
+    pruned : [Association[,...]]
+        Pruned list of associations
+    """
+    pruned = prune_duplicate_associations(asns)
+    pruned = prune_duplicate_products(pruned)
+    return pruned
+
 def prune_duplicate_associations(asns):
     """Remove duplicate associations in favor of lower level versions
 

--- a/jwst/associations/lib/product_utils.py
+++ b/jwst/associations/lib/product_utils.py
@@ -185,12 +185,11 @@ def prune_duplicate_products(asns):
                         asn_keeper, asn = asn, asn_keeper
                     to_prune.append(asn)
                 else:
-                    # There are significant other differences. Discard the lower one but warn.
+                    # There are significant other differences.
                     logger.warning('Following associations have the same product name but significant differences.')
                     logger.warning('Association 1: %s', asn_keeper)
                     logger.warning('Association 2: %s', asn)
                     logger.warning('Diffs: %s', diffs)
-                    to_prune.append(asn)
             else:
                 # Associations are exactly the same. Discard the logically lesser one.
                 # Due to the sorting, this should be the current `asn`

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -33,7 +33,7 @@ from jwst.associations.lib.dms_base import (
 )
 from jwst.associations.lib.member import Member
 from jwst.associations.lib.process_list import ListCategory
-from jwst.associations.lib.product_utils import prune_duplicate_products
+from jwst.associations.lib.product_utils import prune
 from jwst.associations.lib.rules_level3_base import _EMPTY, DMS_Level3_Base
 from jwst.associations.lib.rules_level3_base import Utility as Utility_Level3
 from jwst.associations.lib.utilities import getattr_from_list, getattr_from_list_nofail
@@ -572,7 +572,7 @@ class Utility():
         # Suppress warnings.
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
-            lv2_asns = prune_duplicate_products(lv2_asns)
+            lv2_asns = prune(lv2_asns)
 
         # Ensure sequencing is correct.
         Utility_Level3.resequence(lv2_asns)

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -40,7 +40,7 @@ from jwst.associations.lib.dms_base import (
 )
 from stpipe.format_template import FormatTemplate
 from jwst.associations.lib.member import Member
-from jwst.associations.lib.product_utils import prune_duplicate_associations, prune_duplicate_products
+from jwst.associations.lib.product_utils import prune
 
 __all__ = [
     'ASN_SCHEMA',
@@ -579,8 +579,7 @@ class Utility():
             else:
                 finalized_asns.append(asn)
 
-        lv3_asns = prune_duplicate_associations(lv3_asns)
-        lv3_asns = prune_duplicate_products(lv3_asns)
+        lv3_asns = prune(lv3_asns)
 
         # Ensure sequencing is correct.
         Utility.resequence(lv3_asns)

--- a/jwst/associations/lib/tests/test_diff.py
+++ b/jwst/associations/lib/tests/test_diff.py
@@ -4,15 +4,16 @@ import pytest
 
 import jwst.associations.lib.diff as asn_diff
 
-standard_asn = {
+# Test cases for individual associations
+badcandidate_asn = {
     'asn_type': 'test',
-    'asn_id': 'c1001',
+    'asn_id': 'o001',
     'products': [
         {
             'name': 'product_a',
             'members': [
                 {'expname': 'member_a_a', 'exptype': 'science'},
-                {'expname': 'member_a_b', 'exptype': 'science'}
+                {'expname': 'member_a_a', 'exptype': 'science'}
             ]
         },
         {
@@ -23,10 +24,10 @@ standard_asn = {
             ]
         },
         {
-            'name': 'product_c',
+            'name': 'product_d',
             'members': [
-                {'expname': 'member_c_a', 'exptype': 'science'},
-                {'expname': 'member_c_b', 'exptype': 'science'}
+                {'expname': 'member_d_a', 'exptype': 'science'},
+                {'expname': 'member_d_b', 'exptype': 'science'}
             ]
         },
     ]
@@ -60,7 +61,7 @@ badexptype_asn = {
     ]
 }
 
-dup_product_asn = {
+badmember_asn = {
     'asn_type': 'test',
     'asn_id': 'c1001',
     'products': [
@@ -68,35 +69,7 @@ dup_product_asn = {
             'name': 'product_a',
             'members': [
                 {'expname': 'member_a_a', 'exptype': 'science'},
-                {'expname': 'member_a_b', 'exptype': 'science'}
-            ]
-        },
-        {
-            'name': 'product_a',
-            'members': [
-                {'expname': 'member_a_a', 'exptype': 'science'},
-                {'expname': 'member_a_b', 'exptype': 'science'}
-            ]
-        },
-        {
-            'name': 'product_c',
-            'members': [
-                {'expname': 'member_c_a', 'exptype': 'science'},
-                {'expname': 'member_c_b', 'exptype': 'science'}
-            ]
-        },
-    ]
-}
-
-disjoint_product_asn = {
-    'asn_type': 'test',
-    'asn_id': 'c1001',
-    'products': [
-        {
-            'name': 'product_a',
-            'members': [
-                {'expname': 'member_a_a', 'exptype': 'science'},
-                {'expname': 'member_a_b', 'exptype': 'science'}
+                {'expname': 'member_a_a', 'exptype': 'science'}
             ]
         },
         {
@@ -144,7 +117,7 @@ badtype_asn = {
     ]
 }
 
-badmember_asn = {
+disjoint_product_asn = {
     'asn_type': 'test',
     'asn_id': 'c1001',
     'products': [
@@ -152,7 +125,7 @@ badmember_asn = {
             'name': 'product_a',
             'members': [
                 {'expname': 'member_a_a', 'exptype': 'science'},
-                {'expname': 'member_a_a', 'exptype': 'science'}
+                {'expname': 'member_a_b', 'exptype': 'science'}
             ]
         },
         {
@@ -172,15 +145,43 @@ badmember_asn = {
     ]
 }
 
-badcandidate_asn = {
+dup_product_asn = {
     'asn_type': 'test',
-    'asn_id': 'o001',
+    'asn_id': 'c1001',
     'products': [
         {
             'name': 'product_a',
             'members': [
                 {'expname': 'member_a_a', 'exptype': 'science'},
-                {'expname': 'member_a_a', 'exptype': 'science'}
+                {'expname': 'member_a_b', 'exptype': 'science'}
+            ]
+        },
+        {
+            'name': 'product_a',
+            'members': [
+                {'expname': 'member_a_a', 'exptype': 'science'},
+                {'expname': 'member_a_b', 'exptype': 'science'}
+            ]
+        },
+        {
+            'name': 'product_c',
+            'members': [
+                {'expname': 'member_c_a', 'exptype': 'science'},
+                {'expname': 'member_c_b', 'exptype': 'science'}
+            ]
+        },
+    ]
+}
+
+standard_asn = {
+    'asn_type': 'test',
+    'asn_id': 'c1001',
+    'products': [
+        {
+            'name': 'product_a',
+            'members': [
+                {'expname': 'member_a_a', 'exptype': 'science'},
+                {'expname': 'member_a_b', 'exptype': 'science'}
             ]
         },
         {
@@ -191,12 +192,37 @@ badcandidate_asn = {
             ]
         },
         {
-            'name': 'product_d',
+            'name': 'product_c',
             'members': [
-                {'expname': 'member_d_a', 'exptype': 'science'},
-                {'expname': 'member_d_b', 'exptype': 'science'}
+                {'expname': 'member_c_a', 'exptype': 'science'},
+                {'expname': 'member_c_b', 'exptype': 'science'}
             ]
         },
+    ]
+}
+
+# Test cases for association comparison.
+# The products in each association should be considered separate
+# associations to be compared.
+asns_subset = {
+    'asn_type': 'test',
+    'asn_id': 'c1001',
+    'products': [
+        {
+            'name': 'product_a',
+            'members': [
+                {'expname': 'member_a_1', 'exptype': 'science'},
+                {'expname': 'member_a_2', 'exptype': 'science'},
+            ]
+        },
+        {
+            'name': 'product_a',
+            'members': [
+                {'expname': 'member_a_1', 'exptype': 'science'},
+                {'expname': 'member_a_2', 'exptype': 'science'},
+                {'expname': 'member_a_3', 'exptype': 'science'},
+            ]
+        }
     ]
 }
 
@@ -206,6 +232,15 @@ def test_duplicate_members():
     product = badcandidate_asn['products'][0]
     with pytest.raises(asn_diff.DuplicateMembersError):
         asn_diff.check_duplicate_members(product)
+
+
+def test_equivalency():
+    """Test that two associations equivalency
+
+    Success is the fact that no errors happen.
+    """
+    asns = asn_diff.separate_products(standard_asn)
+    asn_diff.compare_asn_lists(asns, asns)
 
 
 @pytest.mark.parametrize(
@@ -248,15 +283,6 @@ def test_fromfiles():
     asn_diff.compare_asn_files(['test.json'], ['test.json'])
 
 
-def test_equivalency():
-    """Test that two associations equivalency
-
-    Success is the fact that no errors happen.
-    """
-    asns = asn_diff.separate_products(standard_asn)
-    asn_diff.compare_asn_lists(asns, asns)
-
-
 def test_separate_products():
     new_asns = asn_diff.separate_products(standard_asn)
 
@@ -266,3 +292,13 @@ def test_separate_products():
         idx = asn['products'][0]['name'][-1]
         for member in asn['products'][0]['members']:
             assert member['expname'][:-2] == 'member' + '_' + idx
+
+
+def test_subset_product():
+    """Test subset identification"""
+    left, right = asn_diff.separate_products(asns_subset)
+    try:
+        asn_diff.compare_product_membership(left['products'][0], right['products'][0])
+    except asn_diff.MultiDiffError as exception:
+        if len(exception) > 1 or not isinstance(exception[0], asn_diff.SubsetError):
+            raise

--- a/jwst/associations/main.py
+++ b/jwst/associations/main.py
@@ -14,13 +14,14 @@ from jwst.associations import (
 )
 from jwst.associations import config
 from jwst.associations.exceptions import AssociationError
-from jwst.associations.lib.dms_base import DMSAttrConstraint
 from jwst.associations.lib.constraint import (
     ConstraintTrue,
 )
+from jwst.associations.lib.dms_base import DMSAttrConstraint
 from jwst.associations.lib.log_config import (log_config, DMS_config)
+from jwst.associations.lib.product_utils import identify_dups
 
-__all__ = ['Main']
+__all__ = ['Main', 'main']
 
 # Configure logging
 logger = log_config(name=__package__)
@@ -493,11 +494,12 @@ def filter_discovered_only(
     and then Association.load will not return proper results.
     """
     # Split the associations along discovered/not discovered lines
+    dups, valid = identify_dups(associations)
     asn_by_ruleset = {
         candidate_ruleset: [],
         discover_ruleset: []
     }
-    for asn in associations:
+    for asn in valid:
         asn_by_ruleset[asn.registry.name].append(asn)
     candidate_list = asn_by_ruleset[candidate_ruleset]
     discover_list = asn_by_ruleset[discover_ruleset]
@@ -517,6 +519,9 @@ def filter_discovered_only(
 
     if keep_candidates:
         discover_list.extend(candidate_list)
+
+    if config.DEBUG:
+        discover_list += dups
     return discover_list
 
 

--- a/jwst/associations/tests/test_level3_duplicate.py
+++ b/jwst/associations/tests/test_level3_duplicate.py
@@ -14,19 +14,16 @@ from jwst.associations.main import (Main, constrain_on_candidates)
 def test_duplicate_names():
     """
     For Level 3 association, there should be no association
-    with the same product name. Generation should produce
-    log messages indicating when duplicate names have been found.
+    with the same product name.
     """
     pool = AssociationPool.read(t_path('data/jw00632_dups.csv'))
     constrain_all_candidates = constrain_on_candidates(None)
     rules = registry_level3_only(global_constraints=constrain_all_candidates)
 
-    with pytest.warns(RuntimeWarning):
-        asns = generate(pool, rules)
+    asns = generate(pool, rules)
 
     # There should only be one association left.
     assert len(asns) == 1
-
 
 
 def test_duplicate_generate():

--- a/jwst/associations/tests/test_level3_duplicate.py
+++ b/jwst/associations/tests/test_level3_duplicate.py
@@ -1,4 +1,5 @@
 """Test for duplication/missing associations"""
+import logging
 import pytest
 
 from jwst.associations.tests.helpers import (
@@ -11,7 +12,7 @@ from jwst.associations import (AssociationPool, generate)
 from jwst.associations.main import (Main, constrain_on_candidates)
 
 
-def test_duplicate_names():
+def test_duplicate_names(caplog):
     """
     For Level 3 association, there should be no association
     with the same product name.
@@ -20,10 +21,18 @@ def test_duplicate_names():
     constrain_all_candidates = constrain_on_candidates(None)
     rules = registry_level3_only(global_constraints=constrain_all_candidates)
 
-    asns = generate(pool, rules)
+    caplog.clear()
+    logger = logging.getLogger('jwst.associations')
+    propagate = logger.propagate
+    logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING):
+            asns = generate(pool, rules)
+    finally:
+        logger.propagate = propagate
 
     # There should only be one association left.
-    assert len(asns) == 1
+    assert "Following associations have the same product name but significant differences" in caplog.text
 
 
 def test_duplicate_generate():


### PR DESCRIPTION
Major changes:

- Allow rate vs. rateints
- Make identification of subsets explicit
- Remove blanket removal of duplicates

This should allow all the new associations that differ only on the rate vs rateints situation.