### PR TITLE
Leave MIRI out of all this plus fixing duplication checking

### DIFF
--- a/jwst/associations/lib/diff.py
+++ b/jwst/associations/lib/diff.py
@@ -373,27 +373,25 @@ def compare_nosuffix(left, right):
             asns=[left, right]
         )])
 
+    diffs = MultiDiffError()
     for left_product in left['products']:
-        left_sciences = set(exposure_name(member['expname'])[0]
-                         for member in left_product['members']
-                         if member['exptype'] == 'science')
+        left_members = set(exposure_name(member['expname'])[0]
+                         for member in left_product['members'])
         for right_product in right['products']:
-            right_sciences = set(exposure_name(member['expname'])[0]
-                              for member in right_product['members']
-                              if member['exptype'] == 'science')
-            if left_sciences == right_sciences:
+            right_members = set(exposure_name(member['expname'])[0]
+                              for member in right_product['members'])
+            if left_members == right_members:
                 break
         else:
             # No right product matches the left product.
             # This is a fail.
-            raise MultiDiffError([DifferentProductSetsError(
-                f'Products have different memberships between {left.asn_name} and {right.asn_name}',
+            diffs.append(DifferentProductSetsError(
+                f'Left product {left_product["name"]} has not counterpart in right products',
                 asns=[left, right]
-            )])
+            ))
 
-    # Every left product has a matching right product.
-    # Except for suffix, the associations are considered a match.
-    return
+    if diffs:
+        raise diffs
 
 
 def compare_product_membership(left, right):

--- a/jwst/associations/lib/dms_base.py
+++ b/jwst/associations/lib/dms_base.py
@@ -7,6 +7,7 @@ from jwst.associations.exceptions import (
 )
 from jwst.associations.lib.acid import ACIDMixin
 from jwst.associations.lib.constraint import (Constraint, AttrConstraint, SimpleConstraint)
+from jwst.associations.lib.diff import MultiDiffError, compare_asns
 from jwst.associations.lib.utilities import getattr_from_list
 
 
@@ -764,6 +765,26 @@ class DMSBaseMixin(ACIDMixin):
         grating_id = format_list(self.constraints['grating'].found_values)
         grating = '{0:0>3s}'.format(str(grating_id))
         return grating
+
+    def __eq__(self, other):
+        """Compare equality of two associations"""
+        result = NotImplemented
+        if isinstance(other, DMSBaseMixin):
+            try:
+                compare_asns(self, other)
+            except MultiDiffError:
+                result = False
+            else:
+                result = True
+
+        return result
+
+    def __ne__(self, other):
+        """Compare inequality of two associations"""
+        if isinstance(other, DMSBaseMixin):
+            return not self.__eq__(other)
+
+        return NotImplemented
 
 
 # -----------------

--- a/jwst/associations/lib/prune.py
+++ b/jwst/associations/lib/prune.py
@@ -76,12 +76,8 @@ def prune_duplicate_associations(asns):
         except IndexError:
             break
         pruned.append(original)
-        if original.asn_name.startswith('dup'):
-            continue
         to_prune = list()
         for asn in ordered_asns:
-            if asn.asn_name.startswith('dup'):
-                continue
             try:
                 diff.compare_product_membership(original['products'][0], asn['products'][0])
             except AssertionError:

--- a/jwst/associations/lib/prune.py
+++ b/jwst/associations/lib/prune.py
@@ -114,47 +114,59 @@ def prune_duplicate_products(asns):
     if not dups:
         return asns
 
-    ordered_asns = sort_by_candidate(asns)
+    ordered_asns = sort_by_candidate(valid_asns)
     asn_by_product = defaultdict(list)
     for asn in ordered_asns:
         asn_by_product[asn['products'][0]['name']].append(asn)
 
-    to_prune = list()
+    full_prune = list()
     for product in dups:
         dup_asns = asn_by_product[product]
-        asn_keeper = dup_asns.pop()
+        to_keep = dup_asns.copy()
         for asn in dup_asns:
-            if asn.asn_name.startswith('dup'):
+            # Association has been removed, ignore
+            if asn in full_prune:
                 continue
 
-            # Check for differences. If none, then the associations are exact duplicates.
-            try:
-                diff.compare_product_membership(asn_keeper['products'][0], asn['products'][0])
-            except diff.MultiDiffError as diffs:
-                # If one is a pure subset, remove the smaller association.
-                if len(diffs) == 1 and isinstance(diffs[0], diff.SubsetError):
-                    if len(asn['products'][0]['members']) > len(asn_keeper['products'][0]['members']):
-                        asn_keeper, asn = asn, asn_keeper
-                    to_prune.append(asn)
+            # Check against the set of associations to be kept.
+            to_prune = list()
+            for entrant in to_keep:
+                if entrant == asn:
                     continue
 
-                # If the difference is only in suffix, this is an acceptable duplication of product names.
-                # Trap and do not report.
+                # Check for differences. If none, then the associations are exact duplicates.
                 try:
-                    diff.compare_nosuffix(asn_keeper, asn)
-                except diff.MultiDiffError:
-                    # Something is different. Report but do not remove.
-                    logger.warning('Following associations have the same product name but significant differences.')
-                    logger.warning('Association 1: %s', asn_keeper)
-                    logger.warning('Association 2: %s', asn)
-                    logger.warning('Diffs: %s', diffs)
+                    diff.compare_product_membership(asn['products'][0], entrant['products'][0])
+                except diff.MultiDiffError as diffs:
+                    # If one is a pure subset, remove the smaller association.
+                    if len(diffs) == 1 and isinstance(diffs[0], diff.SubsetError):
+                        if len(entrant['products'][0]['members']) > len(asn['products'][0]['members']):
+                            asn, entrant = entrant, asn
+                        to_prune.append(entrant)
+                        continue
 
-            else:
-                # Associations are exactly the same. Discard the logically lesser one.
-                # Due to the sorting, this should be the current `asn`
-                to_prune.append(asn)
+                    # If the difference is only in suffix, this is an acceptable duplication of product names.
+                    # Trap and do not report.
+                    try:
+                        diff.compare_nosuffix(asn, entrant)
+                    except diff.MultiDiffError:
+                        # Something is different. Report but do not remove.
+                        logger.warning('Following associations have the same product name but significant differences.')
+                        logger.warning('Association 1: %s', asn)
+                        logger.warning('Association 2: %s', entrant)
+                        logger.warning('Diffs: %s', diffs)
 
-    prune_remove(ordered_asns, to_prune, known_dups)
+                else:
+                    # Associations are exactly the same. Discard the logically lesser one.
+                    # Due to the sorting, this should be the current `asn`
+                    to_prune.append(entrant)
+
+            # Update lists.
+            full_prune.extend(to_prune)
+            for asn in to_prune:
+                to_keep.remove(asn)
+
+    prune_remove(ordered_asns, full_prune, known_dups)
     return ordered_asns + known_dups
 
 

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -15,7 +15,6 @@ from jwst.associations import (
     libpath
 )
 from jwst.associations.exceptions import AssociationNotValidError
-from jwst.associations.registry import RegistryMarker
 from jwst.associations.lib.acid import ACID
 from jwst.associations.lib.constraint import (
     Constraint,
@@ -37,6 +36,7 @@ from jwst.associations.lib.prune import prune
 from jwst.associations.lib.rules_level3_base import _EMPTY, DMS_Level3_Base
 from jwst.associations.lib.rules_level3_base import Utility as Utility_Level3
 from jwst.associations.lib.utilities import getattr_from_list, getattr_from_list_nofail
+from jwst.associations.registry import RegistryMarker
 from jwst.lib.suffix import remove_suffix
 
 # Configure logging
@@ -169,22 +169,6 @@ class DMSLevel2bBase(DMSBaseMixin, Association):
         """
         limit_reached = len(self.members_by_type('science')) >= 1
         return limit_reached
-
-    def __eq__(self, other):
-        """Compare equality of two associations"""
-        if isinstance(other, DMSLevel2bBase):
-            result = self.data['asn_type'] == other.data['asn_type']
-            result = result and (self.member_ids == other.member_ids)
-            return result
-
-        return NotImplemented
-
-    def __ne__(self, other):
-        """Compare inequality of two associations"""
-        if isinstance(other, DMSLevel2bBase):
-            return not self.__eq__(other)
-
-        return NotImplemented
 
     def dms_product_name(self):
         """Define product name."""

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -26,7 +26,7 @@ from jwst.associations.lib.rules_level2_base import *
 from jwst.associations.lib.rules_level3_base import DMS_Level3_Base
 
 __all__ = [
-    'Asn_Lv2Coron',
+    'Asn_Lv2CoronAsRate',
     'Asn_Lv2FGS',
     'Asn_Lv2Image',
     'Asn_Lv2ImageNonScience',

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -103,6 +103,7 @@ class Asn_Lv2Image(
         - Image-based science exposures
         - Single science exposure
         - Non-TSO
+        - Non-coronagraphic
     """
 
     def __init__(self, *args, **kwargs):
@@ -113,7 +114,10 @@ class Asn_Lv2Image(
             Constraint_Mode(),
             Constraint_Image_Science(),
             Constraint(
-                [Constraint_TSO()],
+                [
+                    Constraint_Coron(association=self),
+                    Constraint_TSO(),
+                ],
                 reduce=Constraint.notany
             ),
             Constraint(
@@ -126,17 +130,6 @@ class Asn_Lv2Image(
 
         # Now check and continue initialization.
         super(Asn_Lv2Image, self).__init__(*args, **kwargs)
-
-    def is_item_coron(self, item):
-        """Override to ignore coronographic designation
-
-        Coronagraphic data is to be processed both as coronagraphic
-        (by default), but also as just plain imaging. Coronagraphic
-        data is processed using the Asn_Lv2Coron rule. This rule
-        will handle the creation of the image version. It has the
-        effect of using "rate" files as input, instead of "rateints".
-        """
-        return False
 
 
 @RegistryMarker.rule

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -15,17 +15,18 @@ from jwst.associations.lib.rules_level3_base import (
 __all__ = [
     'Asn_Lv3ACQ_Reprocess',
     'Asn_Lv3AMI',
-    'Asn_Lv3Coron',
-    'Asn_Lv3NRCCoronImage',
     'Asn_Lv3Image',
     'Asn_Lv3ImageBackground',
-    'Asn_Lv3SpecAux',
+    'Asn_Lv3MIRCoron',
     'Asn_Lv3MIRMRS',
     'Asn_Lv3MIRMRSBackground',
+    'Asn_Lv3NRCCoron',
+    'Asn_Lv3NRCCoronImage',
     'Asn_Lv3NRSFSS',
     'Asn_Lv3NRSIFU',
     'Asn_Lv3NRSIFUBackground',
     'Asn_Lv3SlitlessSpectral',
+    'Asn_Lv3SpecAux',
     'Asn_Lv3SpectralSource',
     'Asn_Lv3SpectralTarget',
     'Asn_Lv3TSO',
@@ -131,159 +132,6 @@ class Asn_Lv3AMI(AsnMixin_Science):
 
 
 @RegistryMarker.rule
-class Asn_Lv3Coron(AsnMixin_Science):
-    """Level 3 Coronagraphy Association
-
-    Characteristics:
-        - Association type: ``coron3``
-        - Pipeline: ``calwebb_coron3``
-        - Gather science and related PSF exposures
-        - Exclude "extra" NIRCam detectors that don't have target on them
-
-    Notes
-    -----
-    Coronagraphy is nearly completely defined by the association candidates
-    produced by APT.
-    Tracking Issues:
-
-        - `github #311 <https://github.com/STScI-JWST/jwst/issues/311>`_
-    """
-
-    def __init__(self, *args, **kwargs):
-
-        # Setup for checking.
-        self.constraints = Constraint(
-            [
-                Constraint_Optical_Path(),
-                DMSAttrConstraint(
-                    name='exp_type',
-                    sources=['exp_type'],
-                    value=(
-                        'nrc_coron'
-                        '|mir_lyot'
-                        '|mir_4qpm'
-                    ),
-                ),
-                DMSAttrConstraint(
-                    name='target',
-                    sources=['targetid'],
-                    onlyif=lambda item: self.get_exposure_type(item) == 'science',
-                    force_reprocess=ListCategory.EXISTING,
-                    only_on_match=True,
-                ),
-                Constraint(
-                    [DMSAttrConstraint(
-                        name='bkgdtarg',
-                        sources=['bkgdtarg'],
-                        force_unique=False,
-                    )],
-                    reduce=Constraint.notany
-                ),
-                SimpleConstraint(
-                    value=True,
-                    test=lambda value, item: nrccoron_valid_detector(item),
-                    force_unique=False
-                ),
-            ],
-            name='asn_coron'
-        )
-
-        # PSF is required
-        self.validity.update({
-            'has_psf': {
-                'validated': False,
-                'check': lambda entry: entry['exptype'] == 'psf'
-            }
-        })
-
-        # Check and continue initialization.
-        super(Asn_Lv3Coron, self).__init__(*args, **kwargs)
-
-    def _init_hook(self, item):
-        """Post-check and pre-add initialization"""
-
-        self.data['asn_type'] = 'coron3'
-        super(Asn_Lv3Coron, self)._init_hook(item)
-
-
-@RegistryMarker.rule
-class Asn_Lv3NRCCoronImage(AsnMixin_Science):
-    """Level 3 Coronagraphy Association handled as regular imaging
-
-    Characteristics:
-        - Association type: ``image3``
-        - Pipeline: ``calwebb_image3``
-        - Gather science exposures only, no psf exposures
-        - Only include NRC SW images taken in full-frame
-
-    """
-
-    def __init__(self, *args, **kwargs):
-
-        # Setup for checking.
-        self.constraints = Constraint(
-            [
-                Constraint_Optical_Path(),
-                DMSAttrConstraint(
-                    name='exp_type',
-                    sources=['exp_type'],
-                    value=('nrc_coron'),
-                ),
-                DMSAttrConstraint(
-                    name='target',
-                    sources=['targetid'],
-                    onlyif=lambda item: self.get_exposure_type(item) == 'science',
-                    force_reprocess=ListCategory.EXISTING,
-                    only_on_match=True,
-                ),
-                Constraint(
-                    [DMSAttrConstraint(
-                        name='bkgdtarg',
-                        sources=['bkgdtarg'],
-                        force_unique=False,
-                    ),
-                    DMSAttrConstraint(
-                        name='is_psf',
-                        sources=['is_psf'],
-                        value = ('T')
-                    )],
-                    reduce=Constraint.notany
-                ),  
-                DMSAttrConstraint(
-                    name='channel',
-                    sources=['channel'],
-                    value=('short'),
-                ),
-                DMSAttrConstraint(
-                    name='subarray',
-                    sources=['subarray'],
-                    value=('full'),
-                ),
-            ],
-        )
-
-        # Check and continue initialization.
-        super(Asn_Lv3NRCCoronImage, self).__init__(*args, **kwargs)
-
-    def _init_hook(self, item):
-        """Post-check and pre-add initialization"""
-
-        self.data['asn_type'] = 'image3'
-        super(Asn_Lv3NRCCoronImage, self)._init_hook(item)
-
-    def is_item_coron(self, item):
-        """Override to ignore coronographic designation
-
-        Coronagraphic data is to be processed both as coronagraphic
-        (by default), but also as just plain imaging. Coronagraphic
-        data is processed using the Asn_Lv3Coron rule. This rule
-        will handle the creation of the image version. It causes
-        the input members to be of type "cal", instead of "calints".
-        """
-        return False
-
-
-@RegistryMarker.rule
 class Asn_Lv3Image(AsnMixin_Science):
     """Level 3 Science Image Association
 
@@ -374,40 +222,57 @@ class Asn_Lv3ImageBackground(AsnMixin_AuxData, AsnMixin_Science):
 
 
 @RegistryMarker.rule
-class Asn_Lv3SpecAux(AsnMixin_AuxData, AsnMixin_Spectrum):
-
-    """Level 3 Spectral Association
+class Asn_Lv3MIRCoron(AsnMixin_Coronagraphy, AsnMixin_Science):
+    """Level 3 Coronagraphy Association
 
     Characteristics:
-        - Association type: ``spec3``
-        - Pipeline: ``calwebb_spec3``
+        - Association type: ``coron3``
+        - Pipeline: ``calwebb_coron3``
+        - MIRI Coronagraphy
+        - Gather science and related PSF exposures
+
+    Notes
+    -----
+    Coronagraphy is nearly completely defined by the association candidates
+    produced by APT.
+    Tracking Issues:
+
+        - `github #311 <https://github.com/STScI-JWST/jwst/issues/311>`_
+        - `JP-3219 <https://jira.stsci.edu/browse/JP-3219>`_
     """
+
     def __init__(self, *args, **kwargs):
 
         # Setup for checking.
-        self.constraints = Constraint([
-            Constraint_Target(association=self),
-            Constraint(
-                [
-                    Constraint_TSO(),
-                ],
-                reduce=Constraint.notany
-            ),
-            DMSAttrConstraint(
-                name='bkgdtarg',
-                sources=['bkgdtarg'],
-                value='T',
-            ),
-            DMSAttrConstraint(
-                name='allowed_bkgdtarg',
-                sources=['exp_type'],
-                value='mir_lrs-fixedslit|nrs_fixedslit',
-            ),
-            Constraint_Optical_Path(),
-        ])
+        self.constraints = Constraint(
+            [
+                Constraint_Optical_Path(),
+                DMSAttrConstraint(
+                    name='exp_type',
+                    sources=['exp_type'],
+                    value='mir_lyot|mir_4qpm',
+                ),
+                DMSAttrConstraint(
+                    name='target',
+                    sources=['targetid'],
+                    onlyif=lambda item: self.get_exposure_type(item) == 'science',
+                    force_reprocess=ListCategory.EXISTING,
+                    only_on_match=True,
+                ),
+                Constraint(
+                    [DMSAttrConstraint(
+                        name='bkgdtarg',
+                        sources=['bkgdtarg'],
+                        force_unique=False,
+                    )],
+                    reduce=Constraint.notany
+                ),
+            ],
+            name='asn_coron'
+        )
 
         # Check and continue initialization.
-        super(Asn_Lv3SpecAux, self).__init__(*args, **kwargs)
+        super(Asn_Lv3MIRCoron, self).__init__(*args, **kwargs)
 
 
 @RegistryMarker.rule
@@ -489,6 +354,142 @@ class Asn_Lv3MIRMRSBackground(AsnMixin_AuxData, AsnMixin_Spectrum):
     @property
     def dms_product_name(self):
         return dms_product_name_noopt(self)
+
+
+@RegistryMarker.rule
+class Asn_Lv3NRCCoron(AsnMixin_Coronagraphy, AsnMixin_Science):
+    """Level 3 Coronagraphy Association
+
+    Characteristics:
+        - Association type: ``coron3``
+        - Pipeline: ``calwebb_coron3``
+        - Gather science and related PSF exposures
+        - Exclude "extra" NIRCam detectors that don't have target on them
+
+    Notes
+    -----
+    Coronagraphy is nearly completely defined by the association candidates
+    produced by APT.
+    Tracking Issues:
+
+        - `github #311 <https://github.com/STScI-JWST/jwst/issues/311>`_
+        - `JP-3219 <https://jira.stsci.edu/browse/JP-3219>`_
+    """
+
+    def __init__(self, *args, **kwargs):
+
+        # Setup for checking.
+        self.constraints = Constraint(
+            [
+                Constraint_Optical_Path(),
+                DMSAttrConstraint(
+                    name='exp_type',
+                    sources=['exp_type'],
+                    value=('nrc_coron'),
+                ),
+                DMSAttrConstraint(
+                    name='target',
+                    sources=['targetid'],
+                    onlyif=lambda item: self.get_exposure_type(item) == 'science',
+                    force_reprocess=ListCategory.EXISTING,
+                    only_on_match=True,
+                ),
+                Constraint(
+                    [DMSAttrConstraint(
+                        name='bkgdtarg',
+                        sources=['bkgdtarg'],
+                        force_unique=False,
+                    )],
+                    reduce=Constraint.notany
+                ),
+                SimpleConstraint(
+                    value=True,
+                    test=lambda value, item: nrccoron_valid_detector(item),
+                    force_unique=False
+                ),
+            ],
+            name='asn_coron'
+        )
+
+        # Check and continue initialization.
+        super(Asn_Lv3NRCCoron, self).__init__(*args, **kwargs)
+
+
+@RegistryMarker.rule
+class Asn_Lv3NRCCoronImage(AsnMixin_Science):
+    """Level 3 Coronagraphy Association handled as regular imaging
+
+    Characteristics:
+        - Association type: ``image3``
+        - Pipeline: ``calwebb_image3``
+        - Gather science exposures only, no psf exposures
+        - Only include NRC SW images taken in full-frame
+
+    """
+
+    def __init__(self, *args, **kwargs):
+
+        # Setup for checking.
+        self.constraints = Constraint(
+            [
+                Constraint_Optical_Path(),
+                DMSAttrConstraint(
+                    name='exp_type',
+                    sources=['exp_type'],
+                    value=('nrc_coron'),
+                ),
+                DMSAttrConstraint(
+                    name='target',
+                    sources=['targetid'],
+                    onlyif=lambda item: self.get_exposure_type(item) == 'science',
+                    force_reprocess=ListCategory.EXISTING,
+                    only_on_match=True,
+                ),
+                Constraint(
+                    [DMSAttrConstraint(
+                        name='bkgdtarg',
+                        sources=['bkgdtarg'],
+                        force_unique=False,
+                    ),
+                    DMSAttrConstraint(
+                        name='is_psf',
+                        sources=['is_psf'],
+                        value = ('T')
+                    )],
+                    reduce=Constraint.notany
+                ),  
+                DMSAttrConstraint(
+                    name='channel',
+                    sources=['channel'],
+                    value=('short'),
+                ),
+                DMSAttrConstraint(
+                    name='subarray',
+                    sources=['subarray'],
+                    value=('full'),
+                ),
+            ],
+        )
+
+        # Check and continue initialization.
+        super(Asn_Lv3NRCCoronImage, self).__init__(*args, **kwargs)
+
+    def _init_hook(self, item):
+        """Post-check and pre-add initialization"""
+
+        self.data['asn_type'] = 'image3'
+        super(Asn_Lv3NRCCoronImage, self)._init_hook(item)
+
+    def is_item_coron(self, item):
+        """Override to ignore coronographic designation
+
+        Coronagraphic data is to be processed both as coronagraphic
+        (by default), but also as just plain imaging. Coronagraphic
+        data is processed using the Asn_Lv3Coron rule. This rule
+        will handle the creation of the image version. It causes
+        the input members to be of type "cal", instead of "calints".
+        """
+        return False
 
 
 @RegistryMarker.rule
@@ -690,6 +691,43 @@ class Asn_Lv3SlitlessSpectral(AsnMixin_Spectrum):
 
         # Check and continue initialization.
         super(Asn_Lv3SlitlessSpectral, self).__init__(*args, **kwargs)
+
+
+@RegistryMarker.rule
+class Asn_Lv3SpecAux(AsnMixin_AuxData, AsnMixin_Spectrum):
+
+    """Level 3 Spectral Association
+
+    Characteristics:
+        - Association type: ``spec3``
+        - Pipeline: ``calwebb_spec3``
+    """
+    def __init__(self, *args, **kwargs):
+
+        # Setup for checking.
+        self.constraints = Constraint([
+            Constraint_Target(association=self),
+            Constraint(
+                [
+                    Constraint_TSO(),
+                ],
+                reduce=Constraint.notany
+            ),
+            DMSAttrConstraint(
+                name='bkgdtarg',
+                sources=['bkgdtarg'],
+                value='T',
+            ),
+            DMSAttrConstraint(
+                name='allowed_bkgdtarg',
+                sources=['exp_type'],
+                value='mir_lrs-fixedslit|nrs_fixedslit',
+            ),
+            Constraint_Optical_Path(),
+        ])
+
+        # Check and continue initialization.
+        super(Asn_Lv3SpecAux, self).__init__(*args, **kwargs)
 
 
 @RegistryMarker.rule

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -45,6 +45,7 @@ from jwst.associations.lib.prune import prune
 __all__ = [
     'ASN_SCHEMA',
     'AsnMixin_AuxData',
+    'AsnMixin_Coronagraphy',
     'AsnMixin_Science',
     'AsnMixin_Spectrum',
     'Constraint',
@@ -853,6 +854,26 @@ class AsnMixin_AuxData:
         if exp_type in NEVER_CHANGE:
             return exp_type
         return 'science'
+
+
+class AsnMixin_Coronagraphy:
+    """Basic overrides for Coronagraphy associations"""
+    def __init__(self, *args, **kwargs):
+
+        # PSF is required
+        self.validity.update({
+            'has_psf': {
+                'validated': False,
+                'check': lambda entry: entry['exptype'] == 'psf'
+            }
+        })
+
+        super().__init__(*args, **kwargs)
+
+    def _init_hook(self, item):
+        """Post-check and pre-add initialization"""
+        self.data['asn_type'] = 'coron3'
+        super()._init_hook(item)
 
 
 class AsnMixin_Science(DMS_Level3_Base):

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -129,22 +129,6 @@ class DMS_Level3_Base(DMSBaseMixin, Association):
     def current_product(self):
         return self.data['products'][-1]
 
-    def __eq__(self, other):
-        """Compare equality of two associations"""
-        if isinstance(other, DMS_Level3_Base):
-            result = self.data['asn_type'] == other.data['asn_type']
-            result = result and (self.member_ids == other.member_ids)
-            return result
-
-        return NotImplemented
-
-    def __ne__(self, other):
-        """Compare inequality of two associations"""
-        result = self.__eq__(other)
-        if result is not NotImplemented:
-            result = not result
-        return result
-
     @property
     def dms_product_name(self):
         """Define product name.

--- a/jwst/associations/tests/test_main.py
+++ b/jwst/associations/tests/test_main.py
@@ -17,12 +17,12 @@ POOL_PATH = 'pool_018_all_exptypes.csv'
 
 @pytest.mark.parametrize(
     'case', [
-        (None, 65),  # Don't re-run, just compare to the generator fixture results
+        (None, 61),  # Don't re-run, just compare to the generator fixture results
         (['-i', 'o001'], 2),
         (['-i', 'o001', 'o002'], 3),
-        (['-i', 'c1001'], 0),
-        (['-i', 'o001', 'c1001'], 2),
-        (['-i', 'c1001', 'c1002'], 0),
+        (['-i', 'c1001'], 1),
+        (['-i', 'o001', 'c1001'], 3),
+        (['-i', 'c1001', 'c1002'], 2),
     ]
 )
 def test_asn_candidates(pool, all_candidates, case):

--- a/jwst/regtest/test_associations_sdp_pools.py
+++ b/jwst/regtest/test_associations_sdp_pools.py
@@ -87,13 +87,13 @@ SPECIAL_POOLS = {
         'xfail': None,
         'slow': True,
     },
-    'jw01290_20230304t140931_pool': {
-        'args': [],
-        'xfail': None,
-        'slow': True,
-    },
     'jw01288_c1005_mostilno12_pool': {
         'args': ['-i', 'o003', 'c1001', 'c1005'],
+        'xfail': 'See issue JP-3230',
+        'slow': True,
+    },
+    'jw01290_20230304t140931_pool': {
+        'args': [],
         'xfail': None,
         'slow': True,
     },


### PR DESCRIPTION
Main goal is to make the desired changes only happen for NIRCam. Side changes is improvement of association comparison.

A new regression has occurred which will be handled by JP-3230 after this work is done.

There is a pair of associations from the test pool, jw00016, that will be created that share the same product name. In my testing, they are named

- jw00016-c1002_coron3_00001_asn
- jw00016-c1002_image3_00001_asn

The product name is "jw00016-c1002_t004_nircam_f210m-maskbar".  One is the desired Level 3 coronagraphic product. The "image3" version is the new, "cal"-based product of the same exposures. I do not know offhande if calwebb_coron3 creates different suffixes for its output as compared to calwebb_image3. If the suffixes are mutually exclusive, sharing the product name is OK. However, if the suffixes are not mutually exclusive, then we have a name collision problem.

Offhand, I do not have a solution to that issue.

The following are expected regressions which, when the PR is finally deemed correct, can be okified.

> test_associations_sdp_pools.py::test_against_standard[jw93025_20171108T062313_pool]
test_associations_sdp_pools.py::test_against_standard[jw01194_20230115t113819_pool]
test_associations_sdp_pools.py::test_against_standard[jw10005_20181020T033546_pool]
test_associations_sdp_pools.py::test_against_standard[jw82600_20180921T023255_pool]
test_associations_standards.py::test_against_standard[pool_013_coron_nircam]
test_associations_sdp_pools.py::test_against_standard[jw00628_20191102t153956_pool]