### PR TITLE
Fix bug in ASN diffing where wrong diff function is called

### DIFF
--- a/jwst/associations/lib/diff.py
+++ b/jwst/associations/lib/diff.py
@@ -181,7 +181,7 @@ def compare_asn_lists(left_asns, right_asns):
             diffs.extend(dup_errors)
     if right_duplicates:
         try:
-            check_duplicate_members(right_asns)
+            check_duplicate_products(right_asns)
         except MultiDiffError as dup_errors:
             diffs.extend(dup_errors)
 

--- a/jwst/regtest/test_associations_sdp_pools.py
+++ b/jwst/regtest/test_associations_sdp_pools.py
@@ -32,6 +32,11 @@ SPECIAL_DEFAULT = {
     'slow': False,
 }
 SPECIAL_POOLS = {
+    'jw00016_20230331t130733_pool': {
+        'args': [],
+        'xfail': 'See issue JP-3230',
+        'slow': False,
+    },
     'jw00623_20190607t021101_pool': {
         'args': [],
         'xfail': None,


### PR DESCRIPTION
Also XFAILed the new test because the code is actually doing what it is supposed to, which is triggering a new issue.